### PR TITLE
feat: skip existing audio files (fixes #54)

### DIFF
--- a/montaigne/__init__.py
+++ b/montaigne/__init__.py
@@ -9,7 +9,7 @@ A unified tool for processing presentations:
 - Generate videos from slides and audio
 """
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 from .pdf import extract_pdf_pages
 from .scripts import generate_scripts, generate_slide_script

--- a/montaigne/audio.py
+++ b/montaigne/audio.py
@@ -259,6 +259,7 @@ def generate_audio(
     voice: Optional[str] = None,
     provider: str = "gemini",
     model: Optional[str] = None,
+    force: bool = False,
 ) -> List[Path]:
     """Main entry point to generate audio for a full script.
 
@@ -268,6 +269,7 @@ def generate_audio(
         voice: Voice name to use
         provider: TTS provider ("gemini", "elevenlabs", or "coqui")
         model: Optional Gemini model name (default: gemini-2.5-flash-preview-tts)
+        force: If True, regenerate all audio even if files already exist
 
     Returns:
         List of paths to generated audio files
@@ -315,9 +317,19 @@ def generate_audio(
 
     slide_iterator = tqdm(slides, desc=f"Generating {provider} audio") if use_tqdm else slides
 
+    skipped = 0
     for slide in slide_iterator:
         try:
             output_path = output_dir / f"slide_{slide['number']:02d}.{extension}"
+
+            if not force and output_path.exists():
+                if use_tqdm:
+                    tqdm.write(f"  Skipping Slide {slide['number']} (already exists)")
+                else:
+                    logger.info("Skipping Slide %d (already exists): %s", slide["number"], output_path.name)
+                generated_files.append(output_path)
+                skipped += 1
+                continue
 
             if is_eleven:
                 generate_slide_audio_elevenlabs(
@@ -369,5 +381,8 @@ def generate_audio(
             else:
                 logger.error(msg)
 
-    logger.info("Success! Generated %d files in %s/", len(generated_files), output_dir)
+    if skipped:
+        logger.info("Done! %d generated, %d skipped (already existed) in %s/", len(generated_files) - skipped, skipped, output_dir)
+    else:
+        logger.info("Success! Generated %d files in %s/", len(generated_files), output_dir)
     return generated_files

--- a/montaigne/cli.py
+++ b/montaigne/cli.py
@@ -194,6 +194,7 @@ def cmd_audio(args):
         voice=args.voice,
         provider=args.provider,
         model=args.model,
+        force=args.force,
     )
 
 
@@ -958,6 +959,11 @@ One-command video:
         "-m",
         default=None,
         help="Gemini model for TTS (default: gemini-2.5-pro-preview-tts)",
+    )
+    audio_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate all audio files, even if they already exist",
     )
 
     # Translate command (image translation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "montaigne"
-version = "1.2.0"
+version = "1.3.0"
 description = "Media processing toolkit for presentation localization"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -5,8 +5,11 @@ import base64
 import struct
 from pathlib import Path
 
+from unittest.mock import patch, MagicMock
+
 from montaigne.audio import (
     parse_voiceover_script,
+    generate_audio,
     _parse_audio_mime_type,
     _decode_audio_data,
     _convert_to_wav,
@@ -222,6 +225,87 @@ class TestConvertToWav:
         # Bits per sample is at bytes 34-36 (little-endian)
         bits_per_sample = struct.unpack("<H", wav_data[34:36])[0]
         assert bits_per_sample == 16
+
+
+class TestSkipExistingAudio:
+    """Tests for skip-existing logic in generate_audio."""
+
+    def test_skips_existing_files(self, sample_voiceover_script, temp_dir):
+        """Existing audio files should be skipped, not regenerated."""
+        output_dir = temp_dir / "audio_out"
+        output_dir.mkdir()
+
+        # Pre-create audio files for slides 1 and 2
+        (output_dir / "slide_01.wav").write_bytes(b"existing-audio-1")
+        (output_dir / "slide_02.wav").write_bytes(b"existing-audio-2")
+
+        with patch("montaigne.audio.generate_slide_audio") as mock_gen, \
+             patch("montaigne.audio.get_gemini_client"):
+            mock_gen.side_effect = lambda text, path, **kw: path.write_bytes(b"new-audio")
+
+            result = generate_audio(sample_voiceover_script, output_dir=output_dir)
+
+        # Should have returned all 3 slides
+        assert len(result) == 3
+        # Only slide 3 should have been generated (slides 1 & 2 skipped)
+        assert mock_gen.call_count == 1
+        # Pre-existing files should be untouched
+        assert (output_dir / "slide_01.wav").read_bytes() == b"existing-audio-1"
+        assert (output_dir / "slide_02.wav").read_bytes() == b"existing-audio-2"
+
+    def test_force_regenerates_existing_files(self, sample_voiceover_script, temp_dir):
+        """With force=True, existing files should be regenerated."""
+        output_dir = temp_dir / "audio_out"
+        output_dir.mkdir()
+
+        # Pre-create audio file for slide 1
+        (output_dir / "slide_01.wav").write_bytes(b"old-audio")
+
+        with patch("montaigne.audio.generate_slide_audio") as mock_gen, \
+             patch("montaigne.audio.get_gemini_client"):
+            mock_gen.side_effect = lambda text, path, **kw: path.write_bytes(b"new-audio")
+
+            result = generate_audio(sample_voiceover_script, output_dir=output_dir, force=True)
+
+        # All 3 slides should have been generated
+        assert mock_gen.call_count == 3
+        assert len(result) == 3
+        # Slide 1 should have been overwritten
+        assert (output_dir / "slide_01.wav").read_bytes() == b"new-audio"
+
+    def test_skip_existing_resumes_after_quota_error(self, temp_dir):
+        """Skip-existing enables resuming after a quota error mid-run."""
+        script_content = """# Test
+## SLIDE 1: First
+**Duration:** 30s
+First slide text.
+---
+## SLIDE 2: Second
+**Duration:** 30s
+Second slide text.
+---
+## SLIDE 3: Third
+**Duration:** 30s
+Third slide text.
+"""
+        script_path = temp_dir / "voiceover.md"
+        script_path.write_text(script_content, encoding="utf-8")
+
+        output_dir = temp_dir / "audio_out"
+        output_dir.mkdir()
+
+        # Simulate: slide 1 was generated before quota hit
+        (output_dir / "slide_01.wav").write_bytes(b"completed-before-quota")
+
+        with patch("montaigne.audio.generate_slide_audio") as mock_gen, \
+             patch("montaigne.audio.get_gemini_client"):
+            mock_gen.side_effect = lambda text, path, **kw: path.write_bytes(b"new")
+
+            result = generate_audio(script_path, output_dir=output_dir)
+
+        # Slide 1 skipped, slides 2 & 3 generated
+        assert mock_gen.call_count == 2
+        assert len(result) == 3
 
 
 class TestVoiceConstants:


### PR DESCRIPTION
## Summary

- Audio generation now **skips slides that already have a `.wav` file**, avoiding redundant TTS API calls and quota waste
- Adds `--force` flag to `essai audio` to override skip behavior when regeneration is needed
- Enables safe **resume after quota errors** or interrupted runs — just re-run the same command

## Changes

- `audio.py`: Added `force` param to `generate_audio()`, skip-existing check in the slide loop, improved summary logging (`3 generated, 6 skipped`)
- `cli.py`: Added `--force` flag to `audio` subparser, wired through to `generate_audio()`
- `tests/test_audio.py`: 3 new tests covering skip, force-override, and quota-resume scenarios
- Version bump: `1.2.0` → `1.3.0`

## Test plan

- [x] All 110 existing tests pass
- [x] New tests: `test_skips_existing_files`, `test_force_regenerates_existing_files`, `test_skip_existing_resumes_after_quota_error`
- [x] Manual: run `essai audio` twice on same script, confirm second run skips all slides
- [x] Manual: run `essai audio --force` on existing output, confirm all files regenerated

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)